### PR TITLE
Updated the script to not produce sourcemap for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "scripts": {
         "start": "react-scripts start",
-        "build": "react-scripts build",
+        "build": "set \"GENERATE_SOURCEMAP=false\" && react-scripts build",
         "test": "react-scripts test",
         "test:ci": "env CI=true react-scripts test",
         "test:cov": "env CI=true react-scripts test --coverage",


### PR DESCRIPTION
# Pull Request Template

## Description

Sourcemaps are getting generated for production build. We need to create production build excluding sourcemaps.

Fixes # (issue) - Prevent generation of source map when app is deployed.

## Type of change

Please mark the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Configuration change and updated in scripts section in package.json

## How Has This Been Tested?

Before this fix, when we are building the application using "npm run build" command, it is producing the source maps. You can refer the image below

![image](https://user-images.githubusercontent.com/22481268/135726587-7c324ae9-dbc0-43f3-aed6-5f7751fea292.png)

After the fix, when i ran the command "npm run build", it is not producing the source maps now. You can refer to the screen shot below which is taken after the fix

![image](https://user-images.githubusercontent.com/22481268/135726611-d6ce1aec-fce5-4a60-b3c9-6b276643138d.png)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
