### PR TITLE
fix: adjust isValidNumber condition

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,6 +17,8 @@ export const isEmptyString = <T,>(value: string | T): boolean =>
  *
  */
 export const isValidNumber = <T,>(value: number | string | T): boolean =>
+    ['number', 'string'].includes(typeof value) &&
+    value !== '' &&
     !isNaN(Number(value));
 
 /**

--- a/src/utils/isValidNumber.test.ts
+++ b/src/utils/isValidNumber.test.ts
@@ -1,7 +1,7 @@
 import { isValidNumber } from '../utils';
 
 test('isValidNumber on empty string', () => {
-    expect(isValidNumber('')).toBe(true);
+    expect(isValidNumber('')).toBe(false);
 });
 
 test('isValidNumber on non-empty string', () => {
@@ -9,7 +9,7 @@ test('isValidNumber on non-empty string', () => {
 });
 
 test('isValidNumber on null and undefined values', () => {
-    expect(isValidNumber(null)).toBe(true);
+    expect(isValidNumber(null)).toBe(false);
     expect(isValidNumber(undefined)).toBe(false);
     expect(isValidNumber('null')).toBe(false);
     expect(isValidNumber('undefined')).toBe(false);
@@ -24,14 +24,14 @@ test('isValidNumber on numbers', () => {
 });
 
 test('isValidNumber on boolean values', () => {
-    expect(isValidNumber(true)).toBe(true);
-    expect(isValidNumber(false)).toBe(true);
+    expect(isValidNumber(true)).toBe(false);
+    expect(isValidNumber(false)).toBe(false);
     expect(isValidNumber('true')).toBe(false);
     expect(isValidNumber('false')).toBe(false);
 });
 
 test('isValidNumber on lists', () => {
-    expect(isValidNumber([])).toBe(true);
+    expect(isValidNumber([])).toBe(false);
     expect(isValidNumber([1, 2, 'lorem ipsum'])).toBe(false);
 });
 


### PR DESCRIPTION
# Pull Request Template

## Description

Like I said on #18 , I've fixed teh isValidNumber to check the type of value, because `Number([]) = 0`, and it's wrong


## Type of change

Please mark the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've adjust the test case of this specific function

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
